### PR TITLE
adds code to create wads and write them to the filesystem

### DIFF
--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
 
@@ -20,22 +21,22 @@ enum TAG {
 };
 
 struct tag {
-	size_t tag;
-	size_t length;
-	size_t offset;
+	uint64_t tag;
+	uint64_t length;
+	uint64_t offset;
 	byte *data;
 };
 
 struct wad {
 	struct tag *tag;
 	byte *read_only_data;
-	short num_wads;
-	short pad;
+	int16_t num_wads;
+	int16_t pad;
 };
 
 struct FileDescriptor {
-	size_t id;
-	short reference_number;
+	uint64_t id;
+	int16_t reference_number;
 	byte name[FD_NAME_SIZE];
 };
 
@@ -45,19 +46,19 @@ struct preferences {
 };
 
 struct player_preferences {
-	size_t last_time_exec;
-	short difficulty_level;
-	short color;
-	short team;
+	uint64_t last_time_exec;
+	int16_t difficulty_level;
+	int16_t color;
+	int16_t team;
 	char name[PREFERENCES_NAME_SIZE];
 	bool background_music_enabled;
 };
 
 static struct preferences *preferences = NULL;
 
-void *wad_extractTypeFromWad(size_t *length, struct wad const *wad, size_t wadDataType);
-void *wad_getDataFromPreferences(size_t preferences,
-				 size_t expected_size,
+void *wad_extractTypeFromWad(uint64_t *length, struct wad const *wad, uint64_t wadDataType);
+void *wad_getDataFromPreferences(uint64_t preferences,
+				 uint64_t expected_size,
 				 void (*initialize) (void *prefs),
 				 bool (*validate) (void *prefs));
 
@@ -66,11 +67,11 @@ int main (void)
 	return 0;
 }
 
-void *wad_extractTypeFromWad (size_t *length, struct wad const *wad, size_t wadDataType)
+void *wad_extractTypeFromWad (uint64_t *length, struct wad const *wad, uint64_t wadDataType)
 {
-	*length = ((size_t) 0);
+	*length = ((uint64_t) 0);
 	void *data = NULL;
-	for (short i = 0; i != wad->num_wads; ++i) {
+	for (int16_t i = 0; i != wad->num_wads; ++i) {
 		if (wad->tag[i].tag == wadDataType) {
 			data = wad->tag[i].data;
 			*length = wad->tag[i].length;
@@ -80,8 +81,8 @@ void *wad_extractTypeFromWad (size_t *length, struct wad const *wad, size_t wadD
 	return data;
 }
 
-void *wad_getDataFromPreferences (size_t tag,
-				  size_t expected_size,
+void *wad_getDataFromPreferences (uint64_t tag,
+				  uint64_t expected_size,
 				  void (*initialize) (void *prefs),
 				  bool (*validate) (void *prefs))
 {

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -85,15 +85,6 @@ void *wad_getDataFromPreferences (size_t tag,
 				  void (*initialize) (void *prefs),
 				  bool (*validate) (void *prefs))
 {
-	short FileError;
-	bool success = true;
-	preferences = (struct preferences*) malloc(sizeof(*preferences));
-	if (!preferences) {
-		return NULL;
-	}
-
-	memset(preferences, 0, sizeof(*preferences));
-
 	return NULL;
 }
 

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -4,12 +4,12 @@
 #include <stdbool.h>
 #include <string.h>
 
+#define MAX_WADFILE_NAME_LEN 63
+#define MAX_WADFILE_NAME_SIZE (MAX_WADFILE_NAME_LEN + 1)
 #define PREFERENCES_NAME_LEN 255
 #define PREFERENCES_NAME_SIZE (PREFERENCES_NAME_LEN + 1)
-#define FD_NAME_LEN 63
+#define FD_NAME_LEN MAX_WADFILE_NAME_LEN
 #define FD_NAME_SIZE (FD_NAME_LEN + 1)
-
-typedef unsigned char byte;
 
 enum TAG {
 	NETWORK_TAG,
@@ -24,20 +24,36 @@ struct tag {
 	uint64_t tag;
 	uint64_t length;
 	uint64_t offset;
-	byte *data;
+	char *data;
 };
 
 struct wad {
 	struct tag *tag;
-	byte *read_only_data;
-	int16_t num_wads;
+	char *read_only_data;
+	int16_t num_tags;
 	int16_t pad;
+};
+
+struct wad_header {
+	uint64_t checksum;
+	uint64_t parent_checksum;
+	int16_t num_wads;
+	char filename[MAX_WADFILE_NAME_SIZE];
+	char explicit_padding[46];
+};
+
+struct entry_header {
+	uint64_t tag;
+	uint64_t length;
+	uint64_t offset;
+	uint64_t next_offset;
 };
 
 struct FileDescriptor {
 	uint64_t id;
+	FILE *handle;
 	int16_t reference_number;
-	byte name[FD_NAME_SIZE];
+	char name[FD_NAME_SIZE];
 };
 
 struct preferences {
@@ -62,8 +78,45 @@ void *wad_getDataFromPreferences(uint64_t preferences,
 				 void (*initialize) (void *prefs),
 				 bool (*validate) (void *prefs));
 
+void wad_fillDefaultWadHeader(struct FileDescriptor *fd,
+			      int16_t num_wads,
+			      struct wad_header *header);
+
+void wad_writeWadHeader(struct FileDescriptor *fd, struct wad_header *header);
+bool wad_writeWad(struct FileDescriptor *fd,
+		  struct wad_header *file_header,
+		  struct wad *wad,
+		  uint64_t offset);
+void wad_createEmptyWad(struct wad *wad);
+
+#define WAD_FILENAME "wadfile.dat"
+
 int main (void)
 {
+	printf("sizeof(struct wad_header): %zu\n", sizeof(struct wad_header));
+	char wadfile[FD_NAME_SIZE] = WAD_FILENAME;
+	FILE *file = fopen(wadfile, "w");
+	if (!file) {
+		printf("main: IO ERROR\n");
+		exit(EXIT_FAILURE);
+	}
+
+	struct FileDescriptor fd = {
+		.id = 0,
+		.handle = file,
+		.reference_number = 0,
+		.name = WAD_FILENAME
+	};
+
+	struct wad_header header;
+	struct wad wad;
+	int16_t num_wads = 1;
+	uint64_t offset = 0;
+	wad_createEmptyWad(&wad);
+	wad_fillDefaultWadHeader(&fd, num_wads, &header);
+	wad_writeWadHeader(&fd, &header);
+	wad_writeWad(&fd, &header, &wad, offset);
+	fclose(file);
 	return 0;
 }
 
@@ -71,7 +124,7 @@ void *wad_extractTypeFromWad (uint64_t *length, struct wad const *wad, uint64_t 
 {
 	*length = ((uint64_t) 0);
 	void *data = NULL;
-	for (int16_t i = 0; i != wad->num_wads; ++i) {
+	for (int16_t i = 0; i != wad->num_tags; ++i) {
 		if (wad->tag[i].tag == wadDataType) {
 			data = wad->tag[i].data;
 			*length = wad->tag[i].length;
@@ -86,7 +139,72 @@ void *wad_getDataFromPreferences (uint64_t tag,
 				  void (*initialize) (void *prefs),
 				  bool (*validate) (void *prefs))
 {
+
 	return NULL;
+}
+
+void wad_fillDefaultWadHeader (struct FileDescriptor *fd,
+			       int16_t num_wads,
+			       struct wad_header *header)
+{
+	memset(header, 0, sizeof(*header));
+	header->num_wads = num_wads;
+	strcpy(header->filename, fd->name);
+}
+
+bool wad_writeWad (struct FileDescriptor *fd,
+		   struct wad_header *file_header,
+		   struct wad *wad,
+		   uint64_t offset)
+{
+	size_t bytes = 0;
+	uint64_t running_offset = 0;
+	struct entry_header header;
+	for (int16_t i = 0; i != wad->num_tags; ++i) {
+		header.tag = wad->tag[i].tag;
+		header.length = wad->tag[i].length;
+		header.offset = wad->tag[i].offset;
+		if (i == wad->num_tags - 1) {
+			header.next_offset = 0;
+		} else {
+			running_offset += header.length + sizeof(struct entry_header);
+			header.next_offset = running_offset;
+		}
+
+		size_t sz_h = fwrite(&header, 1, sizeof(header), fd->handle);
+		if (sz_h != sizeof(header)) {
+			return false;
+		}
+		size_t sz_d = fwrite(wad->tag[i].data, 1, wad->tag[i].length, fd->handle);
+		if (sz_d != wad->tag[i].length) {
+			return false;
+		}
+		size_t sz_header = sz_h;
+		size_t sz_data = sz_d;
+		bytes += (sz_header + sz_data);
+	}
+
+	if (bytes != running_offset) {
+		return false;
+	} else {
+		return true;
+	}
+}
+
+void wad_writeWadHeader (struct FileDescriptor *fd, struct wad_header *header)
+{
+
+	size_t bytes_written = fwrite(header, 1, sizeof(*header), fd->handle);
+	if (bytes_written != sizeof(*header)) {
+		printf("wad_writeWadHeader: unexpected IO Error!");
+		return;
+	}
+	printf("wad_writeWadHeader: bytes-written: %zu\n", bytes_written);
+}
+
+void wad_createEmptyWad (struct wad *wad)
+{
+	memset(wad, 0, sizeof(*wad));
 }
 
 /*


### PR DESCRIPTION
- we are using the functions of the `stdio` to make this possible
- using `stdint` so that we can be sure of the size of entry_header struct (code should be portable in that sense)
- valgrind reports no issues